### PR TITLE
Improve async component mounting

### DIFF
--- a/src/tester.tsx
+++ b/src/tester.tsx
@@ -201,7 +201,7 @@ class Tester {
       this.createShallowWrapper();
     }
 
-    if (mountOpts.async) {
+    if (mountOpts.async !== false) {
       // See https://github.com/enzymejs/enzyme/issues/1587
       await flushPromises();
       await this.refresh();

--- a/src/tester.tsx
+++ b/src/tester.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 
 import {
+  flushPromises,
   getInstance,
   getValue,
   isString,
@@ -201,8 +202,9 @@ class Tester {
     }
 
     if (mountOpts.async) {
-      await this.sleep();
-      this.update();
+      // See https://github.com/enzymejs/enzyme/issues/1587
+      await flushPromises();
+      await this.refresh();
     }
 
     return this;

--- a/src/tester.tsx
+++ b/src/tester.tsx
@@ -202,7 +202,9 @@ class Tester {
     }
 
     if (mountOpts.async !== false) {
-      await this.instance.componentDidMount();
+      if (this.instance) {
+        await this.instance.componentDidMount();
+      }
 
       // See https://github.com/enzymejs/enzyme/issues/1587
       await flushPromises();

--- a/src/tester.tsx
+++ b/src/tester.tsx
@@ -202,6 +202,8 @@ class Tester {
     }
 
     if (mountOpts.async !== false) {
+      await this.instance.componentDidMount();
+
       // See https://github.com/enzymejs/enzyme/issues/1587
       await flushPromises();
       await this.refresh();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@
 
 export function getInstance (component: any) {
   const instance = component.instance();
-  return instance.wrappedInstance || instance;
+  return instance && (instance.wrappedInstance || instance);
 }
 
 export function getValue (tester: any, value: unknown) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,3 +22,7 @@ export function capitalize (string: string) {
 export function isString (value: unknown): value is string {
   return typeof value === 'string' || value instanceof String;
 }
+
+export function flushPromises () {
+  return new Promise((resolve, _reject) => setImmediate(resolve));
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,6 +23,6 @@ export function isString (value: unknown): value is string {
   return typeof value === 'string' || value instanceof String;
 }
 
-export function flushPromises () {
-  return new Promise((resolve, _reject) => setImmediate(resolve));
+export async function flushPromises () {
+  return new Promise<void>((resolve, _reject) => setImmediate(resolve));
 }

--- a/test/tester.test.tsx
+++ b/test/tester.test.tsx
@@ -1,13 +1,35 @@
 /* global it, describe, expect */
-import React from 'react';
+import React, { Component } from 'react';
 import { Tester } from '../src';
+import { sleep } from '../src/utils';
 
 const COMPONENT_ID = 'testing-component';
 
 const MyTestingComponent = (props: any) => <div id={COMPONENT_ID} {...props} />;
 
-describe('Tester', () => {
+class AsyncComponent extends Component {
+  public constructor (props: object) {
+    super(props);
+    this.state = { status: 'loading' };
+  }
 
+  public async componentDidMount () {
+    await sleep(10);
+    this.setState({
+      status: 'done',
+    });
+  }
+
+  public render () {
+    return (
+      <div>
+        {this.state.status}
+      </div>
+    );
+  }
+}
+
+describe('Tester', () => {
   it('Init tests', async () => {
     const tester = await new Tester(MyTestingComponent).mount();
     expect(tester.wrapper).toBeTruthy();
@@ -19,4 +41,10 @@ describe('Tester', () => {
     expect(tester.wrapper).toBeTruthy();
     expect(tester.wrapper.html()).toContain('test-hook-component');
   });
+
+  it('Awaits async componentDidMount', async () => {
+    const tester = await new Tester(AsyncComponent).mount();
+    expect(tester.wrapper.text()).toContain('done');
+  });
+
 });

--- a/test/tester.test.tsx
+++ b/test/tester.test.tsx
@@ -44,7 +44,7 @@ describe('Tester', () => {
 
   it('Awaits async componentDidMount', async () => {
     const tester = await new Tester(AsyncComponent).mount();
-    expect(tester.wrapper.text()).toContain('done');
+    expect(tester.text()).toContain('done');
   });
 
 });


### PR DESCRIPTION
This PR fixes some flakiness we had with some of our tests, mainly by addressing https://github.com/enzymejs/enzyme/issues/1587 and by awaiting the `componentDidMount` of our component.

It also makes tester mount async by default, simplifying our tests.

Example code before:
```
const tester = await new Tester(MyComponent).mount({ async: true });
await tester.refresh(100); // this would be a guess for how long we needed to wait
```

Example code after:
```
const tester = await new Tester(MyComponent).mount();
```