### PR TITLE
Allow props to be either an object or an async function

### DIFF
--- a/dist/interfaces.d.ts
+++ b/dist/interfaces.d.ts
@@ -5,7 +5,7 @@ export interface IMountOps {
     async?: boolean;
 }
 export declare type IOnBeforeMount = (tester: Tester, mountOpts?: IMountOps) => void | Promise<void>;
-export declare type IOnInit = (tester: Tester) => void;
+export declare type IOnInit = (tester: Tester) => Promise<void>;
 export interface IBaseHook {
     [key: string]: any;
     name: string;
@@ -17,7 +17,7 @@ export interface IBaseHook {
 }
 export interface IWrapper extends IBaseHook {
     component: ComponentType;
-    props?: object | ((tester: Tester) => Promise<void>);
+    props?: object | ((tester: Tester) => Promise<object>);
     renderChildren?: boolean;
 }
 export declare type IHook = IBaseHook | IWrapper;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,6 +9,7 @@ export interface IMountOps {
 
 export type IOnBeforeMount = (tester: Tester, mountOpts?: IMountOps) => void | Promise<void>;
 export type IOnInit = (tester: Tester) => void;
+export type IProps = object | ((tester: Tester) => Promise<object>);
 
 export interface IBaseHook {
   [key: string]: any;
@@ -20,7 +21,7 @@ export interface IBaseHook {
 
 export interface IWrapper extends IBaseHook {
   component: ComponentType;
-  props?: object | ((tester: Tester) => Promise<void>);
+  props?: IProps;
   renderChildren?: boolean;
 }
 
@@ -33,7 +34,7 @@ export interface IConfig {
 export interface ITesterOpts {
   mount?: React.ReactNode;
   onBeforeMount?: (tester: Tester) => Promise<void>;
-  props?: object | ((tester: Tester) => Promise<object>);
+  props?: IProps;
   TestedComponent?: ComponentType;
 }
 

--- a/src/tester.tsx
+++ b/src/tester.tsx
@@ -2,7 +2,7 @@ import React, { Fragment, ComponentType } from 'react';
 
 import { flushPromises, getInstance, getValue, isString, sleep } from './utils';
 import ConfigurationClass from './ConfigurationClass';
-import { IHook, ITesterOpts, IWrapper, IOnInit, IOnBeforeMount } from './interfaces';
+import { IHook, ITesterOpts, IWrapper, IOnInit, IOnBeforeMount, IProps } from './interfaces';
 
 type ISelectArg = string | { simulate: (event: string) => void };
 
@@ -40,7 +40,7 @@ class Tester {
   public config: ConfigurationClass;
   public initialMount: React.ReactNode;
   public onBeforeMount?: (tester: Tester) => Promise<void>;
-  public props: object;
+  public props: IProps;
   public TestedComponent: ComponentType;
 
   public wrapper: any;
@@ -157,7 +157,8 @@ class Tester {
       await this.onBeforeMount(this);
     }
 
-    const initialMount = this.initialMount || <this.TestedComponent {...this.props} />;
+    const props = await getValue(this, this.props);
+    const initialMount = this.initialMount || <this.TestedComponent {...props} />;
 
     const WrapperTree = this.getWrappers().reduce<any>((Tree, wrapper) => {
       const wrapperChildren = wrapper.renderChildren !== false && Tree;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,8 +7,8 @@ export function getInstance(component: any) {
   return instance && (instance.wrappedInstance || instance);
 }
 
-export function getValue(tester: any, value: unknown) {
-  return typeof value === 'function' ? value(tester) : value;
+export async function getValue(tester: any, value: unknown) {
+  return typeof value === 'function' ? await value(tester) : value;
 }
 
 export async function sleep(ms: number = 0) {

--- a/test/tester.test.tsx
+++ b/test/tester.test.tsx
@@ -41,4 +41,13 @@ describe('Tester', () => {
     const tester = await new Tester(AsyncComponent).mount();
     expect(tester.text()).toContain('done');
   });
+
+  it('Awaits async props function', async () => {
+    const props = jest.fn(),
+      tester = await new Tester(AsyncComponent, { props });
+
+    expect(props).not.toBeCalled();
+    await tester.mount();
+    expect(props).toBeCalled();
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,22 @@
 {
   "compilerOptions": {
-    "module": "esnext",
-    "importHelpers": true,
+    "baseUrl": "./",
     "declaration": true,
     "esModuleInterop": true,
+    "importHelpers": true,
     "jsx": "react",
     "lib": ["dom", "esnext"],
-    "sourceMap": true,
-    "rootDir": "./src",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
-    "baseUrl": "./",
-    "paths": {
-      "*": ["src/*", "node_modules/*"]
-    }
+    "paths": { "*": ["src/*", "node_modules/*"] },
+    "rootDir": "./src",
+    "sourceMap": true,
+    "strict": true,
+    "target": "es5"
   },
   "include": ["src", "types"]
 }


### PR DESCRIPTION
This makes it easier to set props after the results of onBeforeMount.