### PR TITLE
Wrap mount in act and remove unused initialMount

### DIFF
--- a/src/ConfigurationClass.ts
+++ b/src/ConfigurationClass.ts
@@ -47,26 +47,11 @@ class ConfigurationClass {
       throw new Error(`Tester.registerHook() : A hook named "${hook.name}" already exist.`);
     }
 
-    // Validate hook properties here.
-
     this.hooks[hook.name] = hook;
   }
 
   public getValidHooks(hookProp: string): IHook[] {
-    const hooks: IHook[] = [];
-
-    Object.values(this.hooks).forEach(hook => {
-      let valid = true;
-      if (hookProp && !hook[hookProp]) {
-        valid = false;
-      }
-
-      if (valid) {
-        hooks.push(hook);
-      }
-    });
-
-    return hooks;
+    return Object.values(this.hooks).filter(hook => !hookProp || hook[hookProp]);
   }
 }
 

--- a/test/tester.test.tsx
+++ b/test/tester.test.tsx
@@ -10,6 +10,7 @@ const MyTestingComponent = (props: any) => <div id={COMPONENT_ID} {...props} />;
 interface IAsyncComponentProps {
   label?: string;
 }
+
 class AsyncComponent extends Component<IAsyncComponentProps, { status: string }> {
   public constructor(props: IAsyncComponentProps) {
     super(props);


### PR DESCRIPTION
In lieu of Travis:
```
~/projects/tester (V) ;,,; (V) >: yarn; yarn format; yarn lint; yarn build; yarn test
yarn install v1.22.5
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.42s.
yarn run v1.22.5
$ tsdx lint --fix
Defaulting to "tsdx lint src test"
You can override this in the package.json scripts, like "lint": "tsdx lint src otherDir"

✨  Done in 2.00s.
yarn run v1.22.5
$ tsdx lint
Defaulting to "tsdx lint src test"
You can override this in the package.json scripts, like "lint": "tsdx lint src otherDir"

✨  Done in 1.89s.
yarn run v1.22.5
$ tsdx build
✓ Creating entry file 1.1 secs
⠙ Building modules  2%                  0.1s, estimated 5.5s
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
✓ Building modules 3.2 secs
✨  Done in 5.17s.
yarn run v1.22.5
$ tsdx test
 PASS  test/tester.test.tsx
  Tester
    ✓ Init tests (61ms)
    ✓ Init tests TestHook (7ms)
    ✓ Awaits async componentDidMount (30ms)
    ✓ Handles object props (26ms)
    ✓ Handles function props (24ms)
    ✓ Handles promise props (28ms)
    ✓ Properly calls hooks from setupTests.ts (25ms)

-----------------------|---------|----------|---------|---------|----------------------------------------------------
File                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------|---------|----------|---------|---------|----------------------------------------------------
All files              |   79.14 |    60.78 |   70.73 |   80.34 |
 ConfigurationClass.ts |   90.91 |     62.5 |     100 |      90 | 44,47
 index.ts              |     100 |      100 |     100 |     100 |
 tester.tsx            |   72.63 |    55.88 |   57.69 |   74.68 | 82,102,111,115-119,124-126,131-133,138-141,157,167
 utils.ts              |   93.75 |    77.78 |    87.5 |   92.31 | 23
-----------------------|---------|----------|---------|---------|----------------------------------------------------
Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        2.69s, estimated 3s
Ran all test suites.
✨  Done in 4.13s.
```